### PR TITLE
Utt improve demo presentation

### DIFF
--- a/tests/uttDemo/UTTClient/main.cpp
+++ b/tests/uttDemo/UTTClient/main.cpp
@@ -260,25 +260,14 @@ class UTTClientApp : public UTTBlockchainApp {
   }
 
   void pruneSpentCoins() {
-    // Mark spent coins and delete them all at once since they're kept in a vector
-    for (auto& c : wallet_.coins) {
-      if (hasNullifier(c.null.toUniqueString())) {
-        std::cout << " - \'" << wallet_.getUserPid() << "' removes spent " << fmtCurrency(c.getValue())
-                  << " normal coin.\n";
-        c.val = 0;
-      }
-    }
+    auto result = libutt::Client::pruneSpentCoins(wallet_, nullset_);
 
-    wallet_.coins.erase(
-        std::remove_if(wallet_.coins.begin(), wallet_.coins.end(), [](const libutt::Coin& c) { return c.val == 0; }),
-        wallet_.coins.end());
+    for (const size_t value : result.spentCoins_)
+      std::cout << " - \'" << wallet_.getUserPid() << "' removes spent " << fmtCurrency(value) << " normal coin.\n";
 
-    if (wallet_.budgetCoin && hasNullifier(wallet_.budgetCoin->null.toUniqueString())) {
-      std::cout << " - \'" << wallet_.getUserPid() << "' removes spent " << fmtCurrency(wallet_.budgetCoin->getValue())
+    if (result.spentBudgetCoin_)
+      std::cout << " - \'" << wallet_.getUserPid() << "' removes spent " << fmtCurrency(*result.spentBudgetCoin_)
                 << " budget coin.\n";
-
-      wallet_.budgetCoin.reset();
-    }
   }
 
   void tryClaimCoins(const TxUtt& tx) {

--- a/tests/uttDemo/scripts/clean.sh
+++ b/tests/uttDemo/scripts/clean.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-rm -rf logs/* core.* rocksdb/*
-

--- a/tests/uttDemo/scripts/reset.sh
+++ b/tests/uttDemo/scripts/reset.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+echo "Killing all services..."
+killall utt_replica
+killall payment_service
+echo "Done."
+
+echo "Cleaning files..."
+rm -rf logs/* core.* rocksdb/*
+echo "Done."
+

--- a/utt/CMakeLists.txt
+++ b/utt/CMakeLists.txt
@@ -128,10 +128,10 @@ endif()
 string(APPEND CMAKE_CXX_FLAGS 
     " ${CXX_FLAGS}")
 string(APPEND CMAKE_CXX_FLAGS_DEBUG 
-    " ${CXX_FLAGS_DEBUG}")
+    " ${CXX_FLAGS_DEBUG} -DUTT_LOG_DEBUG")
 # When building with 'cmake -DCMAKE_BUILD_TYPE=Trace'
 string(APPEND CMAKE_CXX_FLAGS_TRACE 
-    " ${CXX_FLAGS_DEBUG} -DTRACE")
+    " ${CXX_FLAGS_DEBUG} -DUTT_LOG_TRACE")
 
 # using Clang
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/utt/libutt/include/utt/BudgetProof.h
+++ b/utt/libutt/include/utt/BudgetProof.h
@@ -54,8 +54,8 @@ class BudgetProof {
 
 #ifndef NDEBUG
     logdbg << "Doing budget proof for TXOs: [ ";
-    for (auto txo : forMeTxos) std::cout << txo << ", ";
-    std::cout << "]" << endl;
+    for (auto txo : forMeTxos) logdbg << txo << ", ";
+    logdbg << "]" << endl;
 #endif
 
     std::vector<Fr> x = random_field_elems(3);

--- a/utt/libutt/include/utt/Client.h
+++ b/utt/libutt/include/utt/Client.h
@@ -14,10 +14,9 @@ size_t calcBudget(const Wallet& w);
 
 struct CreateTxEvent {
   std::string txType_ = "undefined";
-  std::vector<size_t> inputCoinValues_;
-  size_t paymentCoinValue_ = 0;
-  std::optional<size_t> changeCoinValue_;
-  std::optional<size_t> budgetCoinValue_;
+  std::vector<size_t> inputNormalCoinValues_;
+  std::optional<size_t> inputBudgetCoinValue_;
+  std::map<std::string, size_t> recipients_;  // [pid : coinValue]
 };
 
 struct ClaimEvent {

--- a/utt/libutt/include/utt/Client.h
+++ b/utt/libutt/include/utt/Client.h
@@ -9,43 +9,46 @@
 
 namespace libutt::Client {
 
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
 size_t calcBalance(const Wallet& w);
 size_t calcBudget(const Wallet& w);
 
-struct CreateTxEvent {
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+struct CreateTxResult {
   std::string txType_ = "undefined";
   std::vector<size_t> inputNormalCoinValues_;
   std::optional<size_t> inputBudgetCoinValue_;
   std::map<std::string, size_t> recipients_;  // [pid : coinValue]
+  Tx tx;
 };
 
-struct ClaimEvent {
-  bool isBudgetCoin_ = false;
-  size_t value_;
-};
+using CoinStrategy = std::function<CreateTxResult(const Wallet&, const std::string&, size_t)>;
+extern CoinStrategy k_CoinStrategyPreferExactChange;
 
+CreateTxResult createTxForPayment(const Wallet& w,
+                                  const std::string& pid,
+                                  size_t payment,
+                                  const CoinStrategy& strategy = k_CoinStrategyPreferExactChange);
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
 struct PruneCoinsResult {
   std::vector<size_t> spentCoins_;
   std::optional<size_t> spentBudgetCoin_;
 };
 
-using CoinStrategy = std::function<Tx(const Wallet&, const std::string&, size_t, CreateTxEvent&)>;
-extern CoinStrategy k_CoinStrategyPreferExactChange;
-
-Tx createTxForPayment(const Wallet& w,
-                      const std::string& pid,
-                      size_t payment,
-                      CreateTxEvent& outEvent,
-                      const CoinStrategy& strategy = k_CoinStrategyPreferExactChange);
-
 PruneCoinsResult pruneSpentCoins(Wallet& w, const std::set<std::string>& nullset);
 
-void tryClaimCoin(Wallet& w,
-                  const Tx& tx,
-                  size_t txoIdx,
-                  const std::vector<RandSigShare>& sigShares,
-                  const std::vector<size_t>& signerIds,
-                  size_t n,
-                  std::optional<ClaimEvent>& outEvent);
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+struct ClaimCoinResult {
+  bool isBudgetCoin_ = false;
+  size_t value_;
+};
+
+std::optional<ClaimCoinResult> tryClaimCoin(Wallet& w,
+                                            const Tx& tx,
+                                            size_t txoIdx,
+                                            const std::vector<RandSigShare>& sigShares,
+                                            const std::vector<size_t>& signerIds,
+                                            size_t n);
 
 }  // namespace libutt::Client

--- a/utt/libutt/include/utt/Client.h
+++ b/utt/libutt/include/utt/Client.h
@@ -12,12 +12,26 @@ namespace libutt::Client {
 size_t calcBalance(const Wallet& w);
 size_t calcBudget(const Wallet& w);
 
-using CoinStrategy = std::function<Tx(const Wallet&, const std::string&, size_t)>;
+struct CreateTxEvent {
+  std::string txType_ = "undefined";
+  std::vector<size_t> inputCoinValues_;
+  size_t paymentCoinValue_ = 0;
+  std::optional<size_t> changeCoinValue_;
+  std::optional<size_t> budgetCoinValue_;
+};
+
+struct ClaimEvent {
+  bool isBudgetCoin_ = false;
+  size_t value_;
+};
+
+using CoinStrategy = std::function<Tx(const Wallet&, const std::string&, size_t, CreateTxEvent&)>;
 extern CoinStrategy k_CoinStrategyPreferExactChange;
 
 Tx createTxForPayment(const Wallet& w,
                       const std::string& pid,
                       size_t payment,
+                      CreateTxEvent& outEvent,
                       const CoinStrategy& strategy = k_CoinStrategyPreferExactChange);
 
 void tryClaimCoin(Wallet& w,
@@ -25,6 +39,7 @@ void tryClaimCoin(Wallet& w,
                   size_t txoIdx,
                   const std::vector<RandSigShare>& sigShares,
                   const std::vector<size_t>& signerIds,
-                  size_t n);
+                  size_t n,
+                  std::optional<ClaimEvent>& outEvent);
 
 }  // namespace libutt::Client

--- a/utt/libutt/include/utt/Client.h
+++ b/utt/libutt/include/utt/Client.h
@@ -24,6 +24,11 @@ struct ClaimEvent {
   size_t value_;
 };
 
+struct PruneCoinsResult {
+  std::vector<size_t> spentCoins_;
+  std::optional<size_t> spentBudgetCoin_;
+};
+
 using CoinStrategy = std::function<Tx(const Wallet&, const std::string&, size_t, CreateTxEvent&)>;
 extern CoinStrategy k_CoinStrategyPreferExactChange;
 
@@ -32,6 +37,8 @@ Tx createTxForPayment(const Wallet& w,
                       size_t payment,
                       CreateTxEvent& outEvent,
                       const CoinStrategy& strategy = k_CoinStrategyPreferExactChange);
+
+PruneCoinsResult pruneSpentCoins(Wallet& w, const std::set<std::string>& nullset);
 
 void tryClaimCoin(Wallet& w,
                   const Tx& tx,

--- a/utt/libutt/include/utt/Simulation.h
+++ b/utt/libutt/include/utt/Simulation.h
@@ -37,7 +37,7 @@ Wallet createWallet(const Context& ctx,
                     size_t budgetCoinVal);
 
 void assertSerialization(Wallet& inOutWallet);
-Tx assertSerialization(const Context& ctx, const Tx&& inTx);
+Tx sendValidTxOnNetwork(const Context& ctx, const Tx& inTx);
 
 void addNullifiers(const Tx& tx, std::set<std::string>& nullset);
 

--- a/utt/libutt/src/Client.cpp
+++ b/utt/libutt/src/Client.cpp
@@ -258,6 +258,28 @@ Tx createTxForPayment(
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
+PruneCoinsResult pruneSpentCoins(Wallet& w, const std::set<std::string>& nullset) {
+  PruneCoinsResult result;
+
+  for (auto& c : w.coins) {
+    if (nullset.count(c.null.toUniqueString()) > 0) {
+      result.spentCoins_.emplace_back(c.getValue());
+      c.val = 0;
+    }
+  }
+
+  w.coins.erase(std::remove_if(w.coins.begin(), w.coins.end(), [](const libutt::Coin& c) { return c.val == 0; }),
+                w.coins.end());
+
+  if (w.budgetCoin && nullset.count(w.budgetCoin->null.toUniqueString()) > 0) {
+    result.spentBudgetCoin_ = w.budgetCoin->getValue();
+    w.budgetCoin.reset();
+  }
+
+  return result;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
 void tryClaimCoin(Wallet& w,
                   const Tx& tx,
                   size_t txoIdx,

--- a/utt/libutt/src/Client.cpp
+++ b/utt/libutt/src/Client.cpp
@@ -19,9 +19,9 @@ Tx createTx_1t1(const Wallet& w, size_t coinIdx, const std::string& pid, CreateT
   logdbg << "Using $" << inputCoins[0].getValue() << " coin and $" << budgetCoin.getValue() << " bcoin\n";
 
   outEvent.txType_ = "1-to-1 transfer";
-  outEvent.paymentCoinValue_ = payment.as_ulong();
-  outEvent.budgetCoinValue_ = budgetCoin.getValue();
-  outEvent.inputCoinValues_.emplace_back(inputCoins[0].getValue());
+  outEvent.inputNormalCoinValues_.emplace_back(inputCoins[0].getValue());
+  outEvent.inputBudgetCoinValue_ = budgetCoin.getValue();
+  outEvent.recipients_.emplace(pid, payment.as_ulong());
 
   return Tx(w.p, w.ask, inputCoins, budgetCoin, recip, w.bpk, w.rpk);
 }
@@ -47,10 +47,10 @@ Tx createTx_1t2(const Wallet& w, size_t coinIdx, size_t payment, const std::stri
   logdbg << "Change is $" << value2.as_ulong() << '\n';
 
   outEvent.txType_ = "1-to-2 transfer";
-  outEvent.paymentCoinValue_ = value1.as_ulong();
-  outEvent.budgetCoinValue_ = budgetCoin.getValue();
-  outEvent.inputCoinValues_.emplace_back(inputCoins[0].getValue());
-  outEvent.changeCoinValue_ = value2.as_ulong();
+  outEvent.inputNormalCoinValues_.emplace_back(inputCoins[0].getValue());
+  outEvent.inputBudgetCoinValue_ = budgetCoin.getValue();
+  outEvent.recipients_.emplace(pid, value1.as_ulong());
+  outEvent.recipients_.emplace(w.getUserPid(), value2.as_ulong());
 
   return Tx(w.p, w.ask, inputCoins, budgetCoin, recip, w.bpk, w.rpk);
 }
@@ -72,10 +72,10 @@ Tx createTx_2t1(const Wallet& w, size_t coinIdx1, size_t coinIdx2, const std::st
          << budgetCoin.getValue() << " bcoin\n";
 
   outEvent.txType_ = "2-to-1 transfer";
-  outEvent.paymentCoinValue_ = totalValue.as_ulong();
-  outEvent.budgetCoinValue_ = budgetCoin.getValue();
-  outEvent.inputCoinValues_.emplace_back(inputCoins[0].getValue());
-  outEvent.inputCoinValues_.emplace_back(inputCoins[1].getValue());
+  outEvent.inputNormalCoinValues_.emplace_back(inputCoins[0].getValue());
+  outEvent.inputNormalCoinValues_.emplace_back(inputCoins[1].getValue());
+  outEvent.inputBudgetCoinValue_ = budgetCoin.getValue();
+  outEvent.recipients_.emplace(pid, totalValue.as_ulong());
 
   return Tx(w.p, w.ask, inputCoins, budgetCoin, recip, w.bpk, w.rpk);
 }
@@ -107,11 +107,11 @@ Tx createTx_2t2(const Wallet& w,
   logdbg << "Change is $" << value2.as_ulong() << '\n';
 
   outEvent.txType_ = "2-to-2 transfer";
-  outEvent.paymentCoinValue_ = value1.as_ulong();
-  outEvent.budgetCoinValue_ = budgetCoin.getValue();
-  outEvent.inputCoinValues_.emplace_back(inputCoins[0].getValue());
-  outEvent.inputCoinValues_.emplace_back(inputCoins[1].getValue());
-  outEvent.changeCoinValue_ = value2.as_ulong();
+  outEvent.inputNormalCoinValues_.emplace_back(inputCoins[0].getValue());
+  outEvent.inputNormalCoinValues_.emplace_back(inputCoins[1].getValue());
+  outEvent.inputBudgetCoinValue_ = budgetCoin.getValue();
+  outEvent.recipients_.emplace(pid, value1.as_ulong());
+  outEvent.recipients_.emplace(w.getUserPid(), value2.as_ulong());
 
   return Tx(w.p, w.ask, inputCoins, budgetCoin, recip, w.bpk, w.rpk);
 }
@@ -131,9 +131,9 @@ Tx createTx_Self2t1(const Wallet& w, size_t coinIdx1, size_t coinIdx2, CreateTxE
   logdbg << "Using {$" << inputCoins[0].getValue() << ", $" << inputCoins[1].getValue() << "} coins\n";
 
   outEvent.txType_ = "coin-merge";
-  outEvent.paymentCoinValue_ = totalValue.as_ulong();
-  outEvent.inputCoinValues_.emplace_back(inputCoins[0].getValue());
-  outEvent.inputCoinValues_.emplace_back(inputCoins[1].getValue());
+  outEvent.inputNormalCoinValues_.emplace_back(inputCoins[0].getValue());
+  outEvent.inputNormalCoinValues_.emplace_back(inputCoins[1].getValue());
+  outEvent.recipients_.emplace(w.getUserPid(), totalValue.as_ulong());
 
   return Tx(w.p, w.ask, inputCoins, std::nullopt, recip, w.bpk, w.rpk);
 }

--- a/utt/libutt/src/Client.cpp
+++ b/utt/libutt/src/Client.cpp
@@ -4,7 +4,7 @@
 namespace libutt::Client {
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-Tx createTx_1t1(const Wallet& w, size_t coinIdx, const std::string& pid) {
+Tx createTx_1t1(const Wallet& w, size_t coinIdx, const std::string& pid, CreateTxEvent& outEvent) {
   logdbg << "Creating a 1t1 tx from '" << w.ask.getPid() << "' to '" << pid << "'\n";
 
   std::vector<Coin> inputCoins = std::vector<Coin>{w.coins.at(coinIdx)};
@@ -18,11 +18,16 @@ Tx createTx_1t1(const Wallet& w, size_t coinIdx, const std::string& pid) {
   logdbg << "Sending $" << payment.as_ulong() << " payment\n";
   logdbg << "Using $" << inputCoins[0].getValue() << " coin and $" << budgetCoin.getValue() << " bcoin\n";
 
+  outEvent.txType_ = "1-to-1 transfer";
+  outEvent.paymentCoinValue_ = payment.as_ulong();
+  outEvent.budgetCoinValue_ = budgetCoin.getValue();
+  outEvent.inputCoinValues_.emplace_back(inputCoins[0].getValue());
+
   return Tx(w.p, w.ask, inputCoins, budgetCoin, recip, w.bpk, w.rpk);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-Tx createTx_1t2(const Wallet& w, size_t coinIdx, size_t payment, const std::string& pid) {
+Tx createTx_1t2(const Wallet& w, size_t coinIdx, size_t payment, const std::string& pid, CreateTxEvent& outEvent) {
   logdbg << "Creating a 1t2 tx from '" << w.ask.getPid() << "' to '" << pid << "'\n";
 
   std::vector<Coin> inputCoins = std::vector<Coin>{w.coins.at(coinIdx)};
@@ -41,11 +46,17 @@ Tx createTx_1t2(const Wallet& w, size_t coinIdx, size_t payment, const std::stri
   logdbg << "Using $" << inputCoins[0].getValue() << " coin and $" << budgetCoin.getValue() << " bcoin\n";
   logdbg << "Change is $" << value2.as_ulong() << '\n';
 
+  outEvent.txType_ = "1-to-2 transfer";
+  outEvent.paymentCoinValue_ = value1.as_ulong();
+  outEvent.budgetCoinValue_ = budgetCoin.getValue();
+  outEvent.inputCoinValues_.emplace_back(inputCoins[0].getValue());
+  outEvent.changeCoinValue_ = value2.as_ulong();
+
   return Tx(w.p, w.ask, inputCoins, budgetCoin, recip, w.bpk, w.rpk);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-Tx createTx_2t1(const Wallet& w, size_t coinIdx1, size_t coinIdx2, const std::string& pid) {
+Tx createTx_2t1(const Wallet& w, size_t coinIdx1, size_t coinIdx2, const std::string& pid, CreateTxEvent& outEvent) {
   logdbg << "Creating a 2t1 tx from '" << w.ask.getPid() << "' to '" << pid << "'\n";
 
   std::vector<Coin> inputCoins = std::vector<Coin>{w.coins.at(coinIdx1), w.coins.at(coinIdx2)};
@@ -60,11 +71,22 @@ Tx createTx_2t1(const Wallet& w, size_t coinIdx1, size_t coinIdx2, const std::st
   logdbg << "Using {$" << inputCoins[0].getValue() << ", $" << inputCoins[1].getValue() << "} coins and $"
          << budgetCoin.getValue() << " bcoin\n";
 
+  outEvent.txType_ = "2-to-1 transfer";
+  outEvent.paymentCoinValue_ = totalValue.as_ulong();
+  outEvent.budgetCoinValue_ = budgetCoin.getValue();
+  outEvent.inputCoinValues_.emplace_back(inputCoins[0].getValue());
+  outEvent.inputCoinValues_.emplace_back(inputCoins[1].getValue());
+
   return Tx(w.p, w.ask, inputCoins, budgetCoin, recip, w.bpk, w.rpk);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-Tx createTx_2t2(const Wallet& w, size_t coinIdx1, size_t coinIdx2, size_t payment, const std::string& pid) {
+Tx createTx_2t2(const Wallet& w,
+                size_t coinIdx1,
+                size_t coinIdx2,
+                size_t payment,
+                const std::string& pid,
+                CreateTxEvent& outEvent) {
   logdbg << "Creating a 2t2 tx from '" << w.ask.getPid() << "' to '" << pid << "'\n";
 
   std::vector<Coin> inputCoins = std::vector<Coin>{w.coins.at(coinIdx1), w.coins.at(coinIdx2)};
@@ -84,11 +106,18 @@ Tx createTx_2t2(const Wallet& w, size_t coinIdx1, size_t coinIdx2, size_t paymen
          << budgetCoin.getValue() << " bcoin\n";
   logdbg << "Change is $" << value2.as_ulong() << '\n';
 
+  outEvent.txType_ = "2-to-2 transfer";
+  outEvent.paymentCoinValue_ = value1.as_ulong();
+  outEvent.budgetCoinValue_ = budgetCoin.getValue();
+  outEvent.inputCoinValues_.emplace_back(inputCoins[0].getValue());
+  outEvent.inputCoinValues_.emplace_back(inputCoins[1].getValue());
+  outEvent.changeCoinValue_ = value2.as_ulong();
+
   return Tx(w.p, w.ask, inputCoins, budgetCoin, recip, w.bpk, w.rpk);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-Tx createTx_Self2t1(const Wallet& w, size_t coinIdx1, size_t coinIdx2) {
+Tx createTx_Self2t1(const Wallet& w, size_t coinIdx1, size_t coinIdx2, CreateTxEvent& outEvent) {
   logdbg << "Creating a self 2t1 tx for '" << w.ask.getPid() << "'\n";
 
   std::vector<Coin> inputCoins = std::vector<Coin>{w.coins.at(coinIdx1), w.coins.at(coinIdx2)};
@@ -100,6 +129,11 @@ Tx createTx_Self2t1(const Wallet& w, size_t coinIdx1, size_t coinIdx2) {
 
   logdbg << "Merged coin is $" << totalValue.as_ulong() << '\n';
   logdbg << "Using {$" << inputCoins[0].getValue() << ", $" << inputCoins[1].getValue() << "} coins\n";
+
+  outEvent.txType_ = "coin-merge";
+  outEvent.paymentCoinValue_ = totalValue.as_ulong();
+  outEvent.inputCoinValues_.emplace_back(inputCoins[0].getValue());
+  outEvent.inputCoinValues_.emplace_back(inputCoins[1].getValue());
 
   return Tx(w.p, w.ask, inputCoins, std::nullopt, recip, w.bpk, w.rpk);
 }
@@ -115,13 +149,14 @@ size_t calcBalance(const Wallet& w) {
 size_t calcBudget(const Wallet& w) { return w.budgetCoin ? w.budgetCoin->getValue() : 0; }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-CoinStrategy k_CoinStrategyPreferExactChange = [](const Wallet& w, const std::string& pid, size_t payment) -> Tx {
+CoinStrategy k_CoinStrategyPreferExactChange =
+    [](const Wallet& w, const std::string& pid, size_t payment, CreateTxEvent& outEvent) -> Tx {
   // Precondition: 0 < payment <= budget <= balance
 
   // Variant 1: Prefer exact payments (using sorted coins)
   //
-  // (1) look for a single coin where value >= k, an exact coin will be prefered
-  // (2) look for two coins with total value >= k, an exact sum will be prefered
+  // (1) look for a single coin where value >= k, an exact coin will be preferred
+  // (2) look for two coins with total value >= k, an exact sum will be preferred
   // (3) no two coins sum up to k, do a merge on the largest two coins
 
   // Example 1 (1 coin match):
@@ -166,9 +201,9 @@ CoinStrategy k_CoinStrategyPreferExactChange = [](const Wallet& w, const std::st
   if (lb != aux.end()) {
     // We can pay with one coin
     if (lb->first > payment) {
-      return createTx_1t2(w, lb->second, payment, pid);
+      return createTx_1t2(w, lb->second, payment, pid, outEvent);
     } else {
-      return createTx_1t1(w, lb->second, pid);
+      return createTx_1t1(w, lb->second, pid, outEvent);
     }
   } else {  // Try to pay with two coins
     // We know that our balance is enough and no coin is >= payment (because lower_bound == end)
@@ -194,20 +229,21 @@ CoinStrategy k_CoinStrategyPreferExactChange = [](const Wallet& w, const std::st
     }
 
     if (exactMatch) {
-      return createTx_2t1(w, exactMatch->first, exactMatch->second, pid);
+      return createTx_2t1(w, exactMatch->first, exactMatch->second, pid, outEvent);
     } else if (match) {
-      return createTx_2t2(w, match->first, match->second, payment, pid);
+      return createTx_2t2(w, match->first, match->second, payment, pid, outEvent);
     }
   }
 
   // At this point no one or two coins are sufficient to do the payment
   // We merge the top two coins
   const auto lastIdx = aux.size() - 1;
-  return createTx_Self2t1(w, aux[lastIdx - 1].second, aux[lastIdx].second);
+  return createTx_Self2t1(w, aux[lastIdx - 1].second, aux[lastIdx].second, outEvent);
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-Tx createTxForPayment(const Wallet& w, const std::string& pid, size_t payment, const CoinStrategy& strategy) {
+Tx createTxForPayment(
+    const Wallet& w, const std::string& pid, size_t payment, CreateTxEvent& outEvent, const CoinStrategy& strategy) {
   if (!strategy) throw std::runtime_error("Coin strategy not provided!");
   if (w.coins.empty()) throw std::runtime_error("Wallet has no coins!");
   if (pid.empty()) throw std::runtime_error("Empty pid!");
@@ -218,15 +254,17 @@ Tx createTxForPayment(const Wallet& w, const std::string& pid, size_t payment, c
   const size_t budget = calcBudget(w);
   if (budget < payment) throw std::runtime_error("Wallet has insufficient anonymous budget!");
 
-  return strategy(w, pid, payment);
+  return strategy(w, pid, payment, outEvent);
 }
 
+//////////////////////////////////////////////////////////////////////////////////////////////
 void tryClaimCoin(Wallet& w,
                   const Tx& tx,
                   size_t txoIdx,
                   const std::vector<RandSigShare>& sigShares,
                   const std::vector<size_t>& signerIds,
-                  size_t n) {
+                  size_t n,
+                  std::optional<ClaimEvent>& outEvent) {
   auto& txo = tx.outs.at(txoIdx);
 
   Fr val;  // coin value
@@ -307,8 +345,7 @@ void tryClaimCoin(Wallet& w,
   logdbg << "User '" << w.getUserPid() << "' claims " << ((c.isBudget()) ? "budget" : "normal") << " coin $"
          << c.getValue() << '\n';
 
-  // We need to reset the budget coin before we can add a new one that reflects the payment
-  if (c.isBudget()) w.budgetCoin.reset();
+  outEvent = ClaimEvent{c.isBudget(), c.getValue()};
 
   w.addCoin(c);  // Adds either a normal or budget coin
 }

--- a/utt/libutt/src/Client.cpp
+++ b/utt/libutt/src/Client.cpp
@@ -4,9 +4,7 @@
 namespace libutt::Client {
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-Tx createTx_1t1(const Wallet& w, size_t coinIdx, const std::string& pid, CreateTxEvent& outEvent) {
-  logdbg << "Creating a 1t1 tx from '" << w.ask.getPid() << "' to '" << pid << "'\n";
-
+CreateTxResult createTx_1t1(const Wallet& w, size_t coinIdx, const std::string& pid) {
   std::vector<Coin> inputCoins = std::vector<Coin>{w.coins.at(coinIdx)};
   auto budgetCoin = *w.budgetCoin;  // copy
 
@@ -15,21 +13,18 @@ Tx createTx_1t1(const Wallet& w, size_t coinIdx, const std::string& pid, CreateT
   std::vector<std::tuple<std::string, Fr>> recip;
   recip.emplace_back(pid, payment);
 
-  logdbg << "Sending $" << payment.as_ulong() << " payment\n";
-  logdbg << "Using $" << inputCoins[0].getValue() << " coin and $" << budgetCoin.getValue() << " bcoin\n";
+  CreateTxResult result;
+  result.txType_ = "1-to-1 transfer";
+  result.inputNormalCoinValues_.emplace_back(inputCoins[0].getValue());
+  result.inputBudgetCoinValue_ = budgetCoin.getValue();
+  result.recipients_.emplace(pid, payment.as_ulong());
+  result.tx = Tx(w.p, w.ask, inputCoins, budgetCoin, recip, w.bpk, w.rpk);
 
-  outEvent.txType_ = "1-to-1 transfer";
-  outEvent.inputNormalCoinValues_.emplace_back(inputCoins[0].getValue());
-  outEvent.inputBudgetCoinValue_ = budgetCoin.getValue();
-  outEvent.recipients_.emplace(pid, payment.as_ulong());
-
-  return Tx(w.p, w.ask, inputCoins, budgetCoin, recip, w.bpk, w.rpk);
+  return result;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-Tx createTx_1t2(const Wallet& w, size_t coinIdx, size_t payment, const std::string& pid, CreateTxEvent& outEvent) {
-  logdbg << "Creating a 1t2 tx from '" << w.ask.getPid() << "' to '" << pid << "'\n";
-
+CreateTxResult createTx_1t2(const Wallet& w, size_t coinIdx, size_t payment, const std::string& pid) {
   std::vector<Coin> inputCoins = std::vector<Coin>{w.coins.at(coinIdx)};
   auto budgetCoin = *w.budgetCoin;  // copy
 
@@ -42,23 +37,19 @@ Tx createTx_1t2(const Wallet& w, size_t coinIdx, size_t payment, const std::stri
   recip.emplace_back(pid, value1);
   recip.emplace_back(w.ask.getPid(), value2);
 
-  logdbg << "Sending $" << value1.as_ulong() << " payment\n";
-  logdbg << "Using $" << inputCoins[0].getValue() << " coin and $" << budgetCoin.getValue() << " bcoin\n";
-  logdbg << "Change is $" << value2.as_ulong() << '\n';
+  CreateTxResult result;
+  result.txType_ = "1-to-2 transfer";
+  result.inputNormalCoinValues_.emplace_back(inputCoins[0].getValue());
+  result.inputBudgetCoinValue_ = budgetCoin.getValue();
+  result.recipients_.emplace(pid, value1.as_ulong());
+  result.recipients_.emplace(w.getUserPid(), value2.as_ulong());
+  result.tx = Tx(w.p, w.ask, inputCoins, budgetCoin, recip, w.bpk, w.rpk);
 
-  outEvent.txType_ = "1-to-2 transfer";
-  outEvent.inputNormalCoinValues_.emplace_back(inputCoins[0].getValue());
-  outEvent.inputBudgetCoinValue_ = budgetCoin.getValue();
-  outEvent.recipients_.emplace(pid, value1.as_ulong());
-  outEvent.recipients_.emplace(w.getUserPid(), value2.as_ulong());
-
-  return Tx(w.p, w.ask, inputCoins, budgetCoin, recip, w.bpk, w.rpk);
+  return result;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-Tx createTx_2t1(const Wallet& w, size_t coinIdx1, size_t coinIdx2, const std::string& pid, CreateTxEvent& outEvent) {
-  logdbg << "Creating a 2t1 tx from '" << w.ask.getPid() << "' to '" << pid << "'\n";
-
+CreateTxResult createTx_2t1(const Wallet& w, size_t coinIdx1, size_t coinIdx2, const std::string& pid) {
   std::vector<Coin> inputCoins = std::vector<Coin>{w.coins.at(coinIdx1), w.coins.at(coinIdx2)};
   auto budgetCoin = *w.budgetCoin;  // copy
 
@@ -67,28 +58,19 @@ Tx createTx_2t1(const Wallet& w, size_t coinIdx1, size_t coinIdx2, const std::st
   std::vector<std::tuple<std::string, Fr>> recip;
   recip.emplace_back(pid, totalValue);
 
-  logdbg << "Sending $" << totalValue.as_ulong() << " payment\n";
-  logdbg << "Using {$" << inputCoins[0].getValue() << ", $" << inputCoins[1].getValue() << "} coins and $"
-         << budgetCoin.getValue() << " bcoin\n";
+  CreateTxResult result;
+  result.txType_ = "2-to-1 transfer";
+  result.inputNormalCoinValues_.emplace_back(inputCoins[0].getValue());
+  result.inputNormalCoinValues_.emplace_back(inputCoins[1].getValue());
+  result.inputBudgetCoinValue_ = budgetCoin.getValue();
+  result.recipients_.emplace(pid, totalValue.as_ulong());
+  result.tx = Tx(w.p, w.ask, inputCoins, budgetCoin, recip, w.bpk, w.rpk);
 
-  outEvent.txType_ = "2-to-1 transfer";
-  outEvent.inputNormalCoinValues_.emplace_back(inputCoins[0].getValue());
-  outEvent.inputNormalCoinValues_.emplace_back(inputCoins[1].getValue());
-  outEvent.inputBudgetCoinValue_ = budgetCoin.getValue();
-  outEvent.recipients_.emplace(pid, totalValue.as_ulong());
-
-  return Tx(w.p, w.ask, inputCoins, budgetCoin, recip, w.bpk, w.rpk);
+  return result;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-Tx createTx_2t2(const Wallet& w,
-                size_t coinIdx1,
-                size_t coinIdx2,
-                size_t payment,
-                const std::string& pid,
-                CreateTxEvent& outEvent) {
-  logdbg << "Creating a 2t2 tx from '" << w.ask.getPid() << "' to '" << pid << "'\n";
-
+CreateTxResult createTx_2t2(const Wallet& w, size_t coinIdx1, size_t coinIdx2, size_t payment, const std::string& pid) {
   std::vector<Coin> inputCoins = std::vector<Coin>{w.coins.at(coinIdx1), w.coins.at(coinIdx2)};
   auto budgetCoin = *w.budgetCoin;  // copy
 
@@ -101,25 +83,20 @@ Tx createTx_2t2(const Wallet& w,
   recip.emplace_back(pid, value1);
   recip.emplace_back(w.ask.getPid(), value2);
 
-  logdbg << "Sending $" << value1.as_ulong() << " payment\n";
-  logdbg << "Using {$" << inputCoins[0].getValue() << ", $" << inputCoins[1].getValue() << "} coins and $"
-         << budgetCoin.getValue() << " bcoin\n";
-  logdbg << "Change is $" << value2.as_ulong() << '\n';
+  CreateTxResult result;
+  result.txType_ = "2-to-2 transfer";
+  result.inputNormalCoinValues_.emplace_back(inputCoins[0].getValue());
+  result.inputNormalCoinValues_.emplace_back(inputCoins[1].getValue());
+  result.inputBudgetCoinValue_ = budgetCoin.getValue();
+  result.recipients_.emplace(pid, value1.as_ulong());
+  result.recipients_.emplace(w.getUserPid(), value2.as_ulong());
+  result.tx = Tx(w.p, w.ask, inputCoins, budgetCoin, recip, w.bpk, w.rpk);
 
-  outEvent.txType_ = "2-to-2 transfer";
-  outEvent.inputNormalCoinValues_.emplace_back(inputCoins[0].getValue());
-  outEvent.inputNormalCoinValues_.emplace_back(inputCoins[1].getValue());
-  outEvent.inputBudgetCoinValue_ = budgetCoin.getValue();
-  outEvent.recipients_.emplace(pid, value1.as_ulong());
-  outEvent.recipients_.emplace(w.getUserPid(), value2.as_ulong());
-
-  return Tx(w.p, w.ask, inputCoins, budgetCoin, recip, w.bpk, w.rpk);
+  return result;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-Tx createTx_Self2t1(const Wallet& w, size_t coinIdx1, size_t coinIdx2, CreateTxEvent& outEvent) {
-  logdbg << "Creating a self 2t1 tx for '" << w.ask.getPid() << "'\n";
-
+CreateTxResult createTx_Self2t1(const Wallet& w, size_t coinIdx1, size_t coinIdx2) {
   std::vector<Coin> inputCoins = std::vector<Coin>{w.coins.at(coinIdx1), w.coins.at(coinIdx2)};
 
   Fr totalValue = inputCoins[0].val + inputCoins[1].val;
@@ -127,15 +104,14 @@ Tx createTx_Self2t1(const Wallet& w, size_t coinIdx1, size_t coinIdx2, CreateTxE
   std::vector<std::tuple<std::string, Fr>> recip;
   recip.emplace_back(w.ask.getPid(), totalValue);
 
-  logdbg << "Merged coin is $" << totalValue.as_ulong() << '\n';
-  logdbg << "Using {$" << inputCoins[0].getValue() << ", $" << inputCoins[1].getValue() << "} coins\n";
+  CreateTxResult result;
+  result.txType_ = "coin-merge";
+  result.inputNormalCoinValues_.emplace_back(inputCoins[0].getValue());
+  result.inputNormalCoinValues_.emplace_back(inputCoins[1].getValue());
+  result.recipients_.emplace(w.getUserPid(), totalValue.as_ulong());
+  result.tx = Tx(w.p, w.ask, inputCoins, std::nullopt, recip, w.bpk, w.rpk);
 
-  outEvent.txType_ = "coin-merge";
-  outEvent.inputNormalCoinValues_.emplace_back(inputCoins[0].getValue());
-  outEvent.inputNormalCoinValues_.emplace_back(inputCoins[1].getValue());
-  outEvent.recipients_.emplace(w.getUserPid(), totalValue.as_ulong());
-
-  return Tx(w.p, w.ask, inputCoins, std::nullopt, recip, w.bpk, w.rpk);
+  return result;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -150,7 +126,7 @@ size_t calcBudget(const Wallet& w) { return w.budgetCoin ? w.budgetCoin->getValu
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 CoinStrategy k_CoinStrategyPreferExactChange =
-    [](const Wallet& w, const std::string& pid, size_t payment, CreateTxEvent& outEvent) -> Tx {
+    [](const Wallet& w, const std::string& pid, size_t payment) -> CreateTxResult {
   // Precondition: 0 < payment <= budget <= balance
 
   // Variant 1: Prefer exact payments (using sorted coins)
@@ -201,9 +177,9 @@ CoinStrategy k_CoinStrategyPreferExactChange =
   if (lb != aux.end()) {
     // We can pay with one coin
     if (lb->first > payment) {
-      return createTx_1t2(w, lb->second, payment, pid, outEvent);
+      return createTx_1t2(w, lb->second, payment, pid);
     } else {
-      return createTx_1t1(w, lb->second, pid, outEvent);
+      return createTx_1t1(w, lb->second, pid);
     }
   } else {  // Try to pay with two coins
     // We know that our balance is enough and no coin is >= payment (because lower_bound == end)
@@ -229,21 +205,23 @@ CoinStrategy k_CoinStrategyPreferExactChange =
     }
 
     if (exactMatch) {
-      return createTx_2t1(w, exactMatch->first, exactMatch->second, pid, outEvent);
+      return createTx_2t1(w, exactMatch->first, exactMatch->second, pid);
     } else if (match) {
-      return createTx_2t2(w, match->first, match->second, payment, pid, outEvent);
+      return createTx_2t2(w, match->first, match->second, payment, pid);
     }
   }
 
   // At this point no one or two coins are sufficient to do the payment
   // We merge the top two coins
   const auto lastIdx = aux.size() - 1;
-  return createTx_Self2t1(w, aux[lastIdx - 1].second, aux[lastIdx].second, outEvent);
+  return createTx_Self2t1(w, aux[lastIdx - 1].second, aux[lastIdx].second);
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-Tx createTxForPayment(
-    const Wallet& w, const std::string& pid, size_t payment, CreateTxEvent& outEvent, const CoinStrategy& strategy) {
+CreateTxResult createTxForPayment(const Wallet& w,
+                                  const std::string& pid,
+                                  size_t payment,
+                                  const CoinStrategy& strategy) {
   if (!strategy) throw std::runtime_error("Coin strategy not provided!");
   if (w.coins.empty()) throw std::runtime_error("Wallet has no coins!");
   if (pid.empty()) throw std::runtime_error("Empty pid!");
@@ -254,7 +232,7 @@ Tx createTxForPayment(
   const size_t budget = calcBudget(w);
   if (budget < payment) throw std::runtime_error("Wallet has insufficient anonymous budget!");
 
-  return strategy(w, pid, payment, outEvent);
+  return strategy(w, pid, payment);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -280,13 +258,12 @@ PruneCoinsResult pruneSpentCoins(Wallet& w, const std::set<std::string>& nullset
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-void tryClaimCoin(Wallet& w,
-                  const Tx& tx,
-                  size_t txoIdx,
-                  const std::vector<RandSigShare>& sigShares,
-                  const std::vector<size_t>& signerIds,
-                  size_t n,
-                  std::optional<ClaimEvent>& outEvent) {
+std::optional<ClaimCoinResult> tryClaimCoin(Wallet& w,
+                                            const Tx& tx,
+                                            size_t txoIdx,
+                                            const std::vector<RandSigShare>& sigShares,
+                                            const std::vector<size_t>& signerIds,
+                                            size_t n) {
   auto& txo = tx.outs.at(txoIdx);
 
   Fr val;  // coin value
@@ -300,7 +277,7 @@ void tryClaimCoin(Wallet& w,
 
   if (!forMe) {
     logtrace << "TXO #" << txoIdx << " is NOT for pid '" << w.ask.pid << "'!" << endl;
-    return;
+    return std::nullopt;
   } else {
     logtrace << "TXO #" << txoIdx << " is for pid '" << w.ask.pid << "'!" << endl;
   }
@@ -364,12 +341,9 @@ void tryClaimCoin(Wallet& w,
   assertTrue(c.hasValidSig(w.bpk));
   assertNotEqual(c.r, Fr::zero());  // should output a re-randomized coin always
 
-  logdbg << "User '" << w.getUserPid() << "' claims " << ((c.isBudget()) ? "budget" : "normal") << " coin $"
-         << c.getValue() << '\n';
-
-  outEvent = ClaimEvent{c.isBudget(), c.getValue()};
-
   w.addCoin(c);  // Adds either a normal or budget coin
+
+  return ClaimCoinResult{c.isBudget(), c.getValue()};
 }
 
 }  // namespace libutt::Client

--- a/utt/libutt/src/Simulation.cpp
+++ b/utt/libutt/src/Simulation.cpp
@@ -39,7 +39,7 @@ void assertSerialization(Wallet& inOutWallet) {
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-Tx assertSerialization(const Context& ctx, const Tx& inTx) {
+Tx sendValidTxOnNetwork(const Context& ctx, const Tx& inTx) {
   auto oldHash = inTx.getHashHex();
   std::stringstream ss;
   ss << inTx;
@@ -55,7 +55,7 @@ Tx assertSerialization(const Context& ctx, const Tx& inTx) {
     testAssertFail("TXN should have verified");
   }
 
-  logdbg << "Validated TXN!" << endl;
+  loginfo << "Validated TXN!" << endl;
   return outTx;
 }
 
@@ -80,7 +80,7 @@ Coin createNormalCoin(const Context& ctx, size_t val, AddrSK& ask) {
   auto val_fr = Fr(static_cast<long>(val));
   std::string typeStr = Coin::typeToString(type);
 
-  // logdbg << "Minting '" << typeStr << "' coin of value " << val << " for " << ask.pid << endl;
+  // loginfo << "Minting '" << typeStr << "' coin of value " << val << " for " << ask.pid << endl;
   Coin c(ctx.p_.getCoinCK(), ctx.p_.null, sn, val_fr, type, exp_date, ask);
 
   // sign *full* coin commitment using bank's SK
@@ -98,7 +98,7 @@ Coin createBudgetCoin(const Context& ctx, size_t val, AddrSK& ask) {
   auto val_fr = Fr(static_cast<long>(val));
   std::string typeStr = Coin::typeToString(type);
 
-  // logdbg << "Minting '" << typeStr << "' coin of value " << val << " for " << ask.pid << endl;
+  // loginfo << "Minting '" << typeStr << "' coin of value " << val << " for " << ask.pid << endl;
   Coin c(ctx.p_.getCoinCK(), ctx.p_.null, sn, val_fr, type, exp_date, ask);
 
   // sign *full* coin commitment using bank's SK
@@ -258,8 +258,8 @@ void signAndClaimOutputCoins(const Context& ctx, Tx& tx, std::vector<Wallet>& w)
 
       if (coin.has_value()) {
         foundIdx = j;
-        logdbg << "Adding a $" << coin->val << " '" << coin->getType() << "' coin to wallet #" << j + 1 << " for '"
-               << w[j].ask.pid << "'" << endl;
+        loginfo << "Adding a $" << coin->val << " '" << coin->getType() << "' coin to wallet #" << j + 1 << " for '"
+                << w[j].ask.pid << "'" << endl;
         w[j].addCoin(*coin);  // add the coin back to the wallet
         break;
       }
@@ -457,7 +457,7 @@ void doPayment_2t2(const Context& ctx,
                    size_t amount,
                    std::set<std::string>& nullset,
                    std::vector<Wallet>& wallets) {
-  logdbg << "Payment 2-to-2 (Payment of two coins with change)" << endl;
+  loginfo << "Payment 2-to-2 (Payment of two coins with change)" << endl;
 
   testAssertGreaterThanOrEqual(w1.coins.size(), 2);
   testAssertNotEqual(c1, c2);
@@ -467,8 +467,8 @@ void doPayment_2t2(const Context& ctx,
   c.push_back(w1.coins.at(c1));
   c.push_back(w1.coins.at(c2));
 
-  logdbg << "'" << w1.ask.pid << "' removing $" << w1.coins.at(c1).getValue() << " coin" << endl;
-  logdbg << "'" << w1.ask.pid << "' removing $" << w1.coins.at(c2).getValue() << " coin" << endl;
+  loginfo << "'" << w1.ask.pid << "' removing $" << w1.coins.at(c1).getValue() << " coin" << endl;
+  loginfo << "'" << w1.ask.pid << "' removing $" << w1.coins.at(c2).getValue() << " coin" << endl;
 
   w1.coins.at(c1).val = 0;
   w1.coins.at(c2).val = 0;
@@ -482,8 +482,8 @@ void doPayment_2t2(const Context& ctx,
   Fr val2 = totalVal - val1;
   testAssertEqual(val1 + val2, totalVal);
 
-  logdbg << "'" << w1.ask.pid << "' sends $" << val1 << " to '" << w2.ask.pid << "'" << endl;
-  logdbg << "'" << w1.ask.pid << "' gets $" << val2 << " change" << endl;
+  loginfo << "'" << w1.ask.pid << "' sends $" << val1 << " to '" << w2.ask.pid << "'" << endl;
+  loginfo << "'" << w1.ask.pid << "' gets $" << val2 << " change" << endl;
 
   // the recipients and their amounts received
   std::vector<std::tuple<std::string, Fr>> recip;
@@ -498,15 +498,15 @@ void doPayment_2t2(const Context& ctx,
 
   Tx tx_temp = Tx(ctx.p_, w1.ask, c, b, recip, ctx.bpk_, ctx.rpk_);
 
-  logdbg << "Created TXN!" << endl;
+  loginfo << "Created TXN!" << endl;
 
-  Tx tx = assertSerialization(ctx, tx_temp);
+  Tx tx = sendValidTxOnNetwork(ctx, tx_temp);
 
   addNullifiers(tx, nullset);
 
   signAndClaimOutputCoins(ctx, tx, wallets);
 
-  logdbg << '\n';
+  loginfo << '\n';
 }
 
 void doPayment_2t1(const Context& ctx,
@@ -516,7 +516,7 @@ void doPayment_2t1(const Context& ctx,
                    size_t c2,
                    std::set<std::string>& nullset,
                    std::vector<Wallet>& wallets) {
-  logdbg << "Payment 2-to-1 (Exact payment of two coins)" << endl;
+  loginfo << "Payment 2-to-1 (Exact payment of two coins)" << endl;
 
   testAssertGreaterThanOrEqual(w1.coins.size(), 2);
   testAssertNotEqual(c1, c2);
@@ -526,8 +526,8 @@ void doPayment_2t1(const Context& ctx,
   c.push_back(w1.coins.at(c1));
   c.push_back(w1.coins.at(c2));
 
-  logdbg << "'" << w1.ask.pid << "' removing $" << w1.coins.at(c1).getValue() << " coin" << endl;
-  logdbg << "'" << w1.ask.pid << "' removing $" << w1.coins.at(c2).getValue() << " coin" << endl;
+  loginfo << "'" << w1.ask.pid << "' removing $" << w1.coins.at(c1).getValue() << " coin" << endl;
+  loginfo << "'" << w1.ask.pid << "' removing $" << w1.coins.at(c2).getValue() << " coin" << endl;
 
   w1.coins.at(c1).val = 0;
   w1.coins.at(c2).val = 0;
@@ -537,7 +537,7 @@ void doPayment_2t1(const Context& ctx,
   // Send both coins with no change
   Fr totalVal = c.at(0).val + c.at(1).val;
 
-  logdbg << "'" << w1.ask.pid << "' sends $" << totalVal << " to '" << w2.ask.pid << "'" << endl;
+  loginfo << "'" << w1.ask.pid << "' sends $" << totalVal << " to '" << w2.ask.pid << "'" << endl;
 
   // the recipients and their amounts received
   std::vector<std::tuple<std::string, Fr>> recip;
@@ -551,15 +551,15 @@ void doPayment_2t1(const Context& ctx,
 
   Tx tx_temp = Tx(ctx.p_, w1.ask, c, b, recip, ctx.bpk_, ctx.rpk_);
 
-  logdbg << "Created TXN!" << endl;
+  loginfo << "Created TXN!" << endl;
 
-  Tx tx = assertSerialization(ctx, tx_temp);
+  Tx tx = sendValidTxOnNetwork(ctx, tx_temp);
 
   addNullifiers(tx, nullset);
 
   signAndClaimOutputCoins(ctx, tx, wallets);
 
-  logdbg << '\n';
+  loginfo << '\n';
 }
 
 void doPayment_1t2(const Context& ctx,
@@ -569,13 +569,13 @@ void doPayment_1t2(const Context& ctx,
                    size_t amount,
                    std::set<std::string>& nullset,
                    std::vector<Wallet>& wallets) {
-  logdbg << "Payment 1-to-2 (Payment of one coin with change)" << endl;
+  loginfo << "Payment 1-to-2 (Payment of one coin with change)" << endl;
 
   testAssertGreaterThanOrEqual(w1.coins.size(), 1);
 
   std::vector<Coin> c;
   c.push_back(w1.coins.at(c1));
-  logdbg << "'" << w1.ask.pid << "' removing $" << w1.coins.at(c1).getValue() << " coin" << endl;
+  loginfo << "'" << w1.ask.pid << "' removing $" << w1.coins.at(c1).getValue() << " coin" << endl;
   w1.coins.erase(w1.coins.begin() + (int)c1);
 
   Fr totalVal = c.at(0).val;
@@ -585,8 +585,8 @@ void doPayment_1t2(const Context& ctx,
   Fr val2 = totalVal - val1;
   testAssertEqual(val1 + val2, totalVal);
 
-  logdbg << "'" << w1.ask.pid << "' sends $" << val1 << " to '" << w2.ask.pid << "'" << endl;
-  logdbg << "'" << w1.ask.pid << "' gets $" << val2 << " change" << endl;
+  loginfo << "'" << w1.ask.pid << "' sends $" << val1 << " to '" << w2.ask.pid << "'" << endl;
+  loginfo << "'" << w1.ask.pid << "' gets $" << val2 << " change" << endl;
 
   // the recipients and their amounts received
   std::vector<std::tuple<std::string, Fr>> recip;
@@ -601,15 +601,15 @@ void doPayment_1t2(const Context& ctx,
 
   Tx tx_temp = Tx(ctx.p_, w1.ask, c, b, recip, ctx.bpk_, ctx.rpk_);
 
-  logdbg << "Created TXN!" << endl;
+  loginfo << "Created TXN!" << endl;
 
-  Tx tx = assertSerialization(ctx, tx_temp);
+  Tx tx = sendValidTxOnNetwork(ctx, tx_temp);
 
   addNullifiers(tx, nullset);
 
   signAndClaimOutputCoins(ctx, tx, wallets);
 
-  logdbg << '\n';
+  loginfo << '\n';
 }
 
 void doPayment_1t1(const Context& ctx,
@@ -618,17 +618,17 @@ void doPayment_1t1(const Context& ctx,
                    size_t c1,
                    std::set<std::string>& nullset,
                    std::vector<Wallet>& wallets) {
-  logdbg << "Payment 1-to-1 (Exact payment of one coin)" << endl;
+  loginfo << "Payment 1-to-1 (Exact payment of one coin)" << endl;
 
   std::vector<Coin> c;
   c.push_back(w1.coins.at(c1));  // remove one coin from the wallet
 
-  logdbg << "'" << w1.ask.pid << "' removing $" << w1.coins.at(c1).getValue() << " coin" << endl;
+  loginfo << "'" << w1.ask.pid << "' removing $" << w1.coins.at(c1).getValue() << " coin" << endl;
   w1.coins.erase(w1.coins.begin() + (int)c1);
 
   // Send a single coin with no change
   Fr totalVal = c.at(0).val;
-  logdbg << "'" << w1.ask.pid << "' sends $" << totalVal << " to '" << w2.ask.pid << "'" << endl;
+  loginfo << "'" << w1.ask.pid << "' sends $" << totalVal << " to '" << w2.ask.pid << "'" << endl;
 
   // the recipients and their amounts received
   std::vector<std::tuple<std::string, Fr>> recip;
@@ -642,15 +642,15 @@ void doPayment_1t1(const Context& ctx,
 
   Tx tx_temp = Tx(ctx.p_, w1.ask, c, b, recip, ctx.bpk_, ctx.rpk_);
 
-  logdbg << "Created TXN!" << endl;
+  loginfo << "Created TXN!" << endl;
 
-  Tx tx = assertSerialization(ctx, tx_temp);
+  Tx tx = sendValidTxOnNetwork(ctx, tx_temp);
 
   addNullifiers(tx, nullset);
 
   signAndClaimOutputCoins(ctx, tx, wallets);
 
-  logdbg << '\n';
+  loginfo << '\n';
 }
 
 void doCoinSplit(const Context& ctx,
@@ -659,7 +659,7 @@ void doCoinSplit(const Context& ctx,
                  size_t amount,
                  std::set<std::string>& nullset,
                  std::vector<Wallet>& wallets) {
-  logdbg << "Self 1-to-2 (Coin split)" << endl;
+  loginfo << "Self 1-to-2 (Coin split)" << endl;
 
   testAssertGreaterThanOrEqual(w.coins.size(), 1);
 
@@ -675,7 +675,7 @@ void doCoinSplit(const Context& ctx,
   Fr val2 = totalVal - val1;
   testAssertEqual(val1 + val2, totalVal);
 
-  logdbg << "'" << w.ask.pid << "' splits $" << totalVal << " into $" << val1 << " and $" << val2 << endl;
+  loginfo << "'" << w.ask.pid << "' splits $" << totalVal << " into $" << val1 << " and $" << val2 << endl;
 
   // the recipients and their amounts received
   std::vector<std::tuple<std::string, Fr>> recip;
@@ -684,20 +684,20 @@ void doCoinSplit(const Context& ctx,
 
   Tx tx_temp = Tx(ctx.p_, w.ask, c, std::nullopt /*no budget*/, recip, ctx.bpk_, ctx.rpk_);
 
-  logdbg << "Created TXN!" << endl;
+  loginfo << "Created TXN!" << endl;
 
-  Tx tx = assertSerialization(ctx, tx_temp);
+  Tx tx = sendValidTxOnNetwork(ctx, tx_temp);
 
   addNullifiers(tx, nullset);
 
   signAndClaimOutputCoins(ctx, tx, wallets);
 
-  logdbg << '\n';
+  loginfo << '\n';
 }
 
 void doCoinMerge(
     const Context& ctx, Wallet& w, size_t c1, size_t c2, std::set<std::string>& nullset, std::vector<Wallet>& wallets) {
-  logdbg << "Self 2-to-1 (Coin merge)" << endl;
+  loginfo << "Self 2-to-1 (Coin merge)" << endl;
 
   testAssertGreaterThanOrEqual(w.coins.size(), 2);
   testAssertNotEqual(c1, c2);
@@ -707,8 +707,8 @@ void doCoinMerge(
   c.push_back(w.coins.at(c1));
   c.push_back(w.coins.at(c2));
 
-  logdbg << "'" << w.ask.pid << "' removing $" << w.coins.at(c1).getValue() << " coin" << endl;
-  logdbg << "'" << w.ask.pid << "' removing $" << w.coins.at(c2).getValue() << " coin" << endl;
+  loginfo << "'" << w.ask.pid << "' removing $" << w.coins.at(c1).getValue() << " coin" << endl;
+  loginfo << "'" << w.ask.pid << "' removing $" << w.coins.at(c2).getValue() << " coin" << endl;
 
   w.coins.at(c1).val = 0;
   w.coins.at(c2).val = 0;
@@ -720,7 +720,7 @@ void doCoinMerge(
   Fr val2 = c.at(1).val;
   Fr totalVal = val1 + val2;
 
-  logdbg << "'" << w.ask.pid << "' merges $" << totalVal << " from $" << val1 << " and $" << val2 << endl;
+  loginfo << "'" << w.ask.pid << "' merges $" << totalVal << " from $" << val1 << " and $" << val2 << endl;
 
   // the recipients and their amounts received
   std::vector<std::tuple<std::string, Fr>> recip;
@@ -728,15 +728,15 @@ void doCoinMerge(
 
   Tx tx_temp = Tx(ctx.p_, w.ask, c, std::nullopt /*no budget*/, recip, ctx.bpk_, ctx.rpk_);
 
-  logdbg << "Created TXN!" << endl;
+  loginfo << "Created TXN!" << endl;
 
-  Tx tx = assertSerialization(ctx, tx_temp);
+  Tx tx = sendValidTxOnNetwork(ctx, tx_temp);
 
   addNullifiers(tx, nullset);
 
   signAndClaimOutputCoins(ctx, tx, wallets);
 
-  logdbg << '\n';
+  loginfo << '\n';
 }
 
 }  // namespace libutt::Simulation

--- a/utt/libutt/test/CMakeLists.txt
+++ b/utt/libutt/test/CMakeLists.txt
@@ -14,7 +14,7 @@ set(utt_test_sources
     TestTxn.cpp
     #TestTxnFlat.cpp
     TestTxnSimulateAll.cpp
-    TestTxnSimulateUTTDemo.cpp
+    #TestTxnSimulateUTTDemo.cpp
     TestTxnSimulateUTTDemo_v2.cpp
     #TestXGCD.cpp
 )

--- a/utt/libutt/test/CMakeLists.txt
+++ b/utt/libutt/test/CMakeLists.txt
@@ -15,6 +15,7 @@ set(utt_test_sources
     #TestTxnFlat.cpp
     TestTxnSimulateAll.cpp
     TestTxnSimulateUTTDemo.cpp
+    TestTxnSimulateUTTDemo_v2.cpp
     #TestXGCD.cpp
 )
 

--- a/utt/libutt/test/TestTxnSimulateUTTDemo.cpp
+++ b/utt/libutt/test/TestTxnSimulateUTTDemo.cpp
@@ -254,7 +254,7 @@ int main(int argc, char* argv[]) {
     const size_t maxPayment = std::min<size_t>(balance, budget);
 
     if (maxPayment == 0) {
-      loginfo << "No payment possible. [balance=" << balance << "] [budget=" << budget << "] Skipping.";
+      loginfo << "No payment possible. [balance=" << balance << "] [budget=" << budget << "] Skipping.\n";
       continue;
     }
 

--- a/utt/libutt/test/TestTxnSimulateUTTDemo.cpp
+++ b/utt/libutt/test/TestTxnSimulateUTTDemo.cpp
@@ -15,8 +15,8 @@ void pickCoinsVaraint1(const Simulation::Context& ctx,
 
   // Variant 1: Prefer exact payments (using sorted coins)
   //
-  // (1) look for a single coin where value >= k, an exact coin will be prefered
-  // (2) look for two coins with total value >= k, an exact sum will be prefered
+  // (1) look for a single coin where value >= k, an exact coin will be preferred
+  // (2) look for two coins with total value >= k, an exact sum will be preferred
   // (3) no two coins sum up to k, do a merge on the largest two coins
 
   // Example 1 (1 coin match):
@@ -64,7 +64,7 @@ void pickCoinsVaraint1(const Simulation::Context& ctx,
       ss << "(" << c.first << ", " << c.second << ")";
     }
     ss << "]\n";
-    logdbg << ss.str();
+    loginfo << ss.str();
 
     auto lb = std::lower_bound(aux.begin(), aux.end(), CoinRef{payment, -1}, cmpCoinValue);
     if (lb != aux.end()) {
@@ -135,7 +135,7 @@ void pickCoinsVaraint2(const Simulation::Context& ctx,
       ss << c.getValue() << ',';
     }
     ss << "]\n";
-    logdbg << ss.str();
+    loginfo << ss.str();
 
     // Special case
     if (w1.coins.size() == 1) {
@@ -168,7 +168,7 @@ void pickCoinsVaraint2(const Simulation::Context& ctx,
     aux.pop();
     assertTrue(aux.empty());
 
-    logdbg << "c1=(" << c1.first << ',' << c1.second << ") c2=(" << c2.first << ',' << c2.second << ")\n";
+    loginfo << "c1=(" << c1.first << ',' << c1.second << ") c2=(" << c2.first << ',' << c2.second << ")\n";
 
     if (c1.first + c2.first >= payment) {  // We can do the payment
       if (c1.first == payment) {
@@ -205,7 +205,7 @@ int main(int argc, char* argv[]) {
 
   Simulation::Context ctx = Simulation::createContext(n, thresh);
 
-  logdbg << "Created decentralized UTT system" << endl;
+  loginfo << "Created decentralized UTT system" << endl;
 
   //////////////////////////////////////////////////////////////////////////////////////////////
   // CREATE ACCOUNT WALLETS
@@ -221,9 +221,9 @@ int main(int argc, char* argv[]) {
   for (size_t i = 0; i < numWallets; ++i)
     wallets.emplace_back(Simulation::createWallet(ctx, "user_" + std::to_string(i + 1), normal_coin_values, budget));
 
-  logdbg << "Created random wallets" << endl;
+  loginfo << "Created random wallets" << endl;
 
-  // nullifer list
+  // nullifier list
   std::set<std::string> nullset;
 
   //////////////////////////////////////////////////////////////////////////////////////////////
@@ -235,8 +235,8 @@ int main(int argc, char* argv[]) {
   size_t numCycles = 20;
 
   for (size_t cycle = 0; cycle < numCycles; cycle++) {
-    logdbg << endl << endl;
-    logdbg << "================ Cycle #" << (cycle + 1) << " ================" << endl;
+    loginfo << endl << endl;
+    loginfo << "================ Cycle #" << (cycle + 1) << " ================" << endl;
 
     // Pick two distinct random wallets
     size_t i = static_cast<size_t>(rand()) % wallets.size();
@@ -254,13 +254,13 @@ int main(int argc, char* argv[]) {
     const size_t maxPayment = std::min<size_t>(balance, budget);
 
     if (maxPayment == 0) {
-      logdbg << "No payment possible. [balance=" << balance << "] [budget=" << budget << "] Skipping.";
+      loginfo << "No payment possible. [balance=" << balance << "] [budget=" << budget << "] Skipping.";
       continue;
     }
 
     const size_t payment = static_cast<size_t>(rand()) % maxPayment + 1;  // [1 .. maxPayment]
 
-    logdbg << "Target payment $" << payment << " from '" << w1.ask.pid << "' to '" << w2.ask.pid << "'\n";
+    loginfo << "Target payment $" << payment << " from '" << w1.ask.pid << "' to '" << w2.ask.pid << "'\n";
 
     // Precondition: 0 < payment <= budget <= balance
 

--- a/utt/libutt/test/TestTxnSimulateUTTDemo_v2.cpp
+++ b/utt/libutt/test/TestTxnSimulateUTTDemo_v2.cpp
@@ -1,0 +1,159 @@
+#include <utt/Configuration.h>
+
+#include <utt/Simulation.h>
+#include <utt/Client.h>
+#include <utt/Replica.h>
+
+#include <functional>
+#include <queue>
+
+int main(int argc, char* argv[]) {
+  (void)argc;
+  (void)argv;
+
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  // CREATE DECENTRALIZED UTT SYSTEM
+  //////////////////////////////////////////////////////////////////////////////////////////////
+
+  Simulation::initialize();
+
+  size_t n = 21;
+  size_t thresh = 12;
+
+  Simulation::Context ctx = Simulation::createContext(n, thresh);
+
+  loginfo << "Created decentralized UTT system" << endl;
+
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  // CREATE ACCOUNT WALLETS
+  //////////////////////////////////////////////////////////////////////////////////////////////
+
+  // Creates users and their wallets
+  size_t numWallets = 10;
+  // Each wallet is initialized with the following normal coins
+  std::vector<size_t> normal_coin_values = {1, 2, 3, 4, 5, 10};
+  size_t budget = 10000;  // Only one budget coin can be stored in the wallet currently
+
+  std::vector<Wallet> wallets;
+  for (size_t i = 0; i < numWallets; ++i)
+    wallets.emplace_back(Simulation::createWallet(ctx, "user_" + std::to_string(i + 1), normal_coin_values, budget));
+
+  loginfo << "Created random wallets" << endl;
+
+  // nullifier list
+  std::set<std::string> nullset;
+
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  // SIMULATE
+  //////////////////////////////////////////////////////////////////////////////////////////////
+
+  assertGreaterThanOrEqual(wallets.size(), 2);
+
+  size_t numCycles = 20;
+
+  for (size_t cycle = 0; cycle < numCycles; cycle++) {
+    loginfo << endl << endl;
+    loginfo << "================ Cycle #" << (cycle + 1) << " ================" << endl;
+
+    // Pick two distinct random wallets
+    size_t i = static_cast<size_t>(rand()) % wallets.size();
+    size_t rand_offset = 1 + (static_cast<size_t>(rand()) % (wallets.size() - 1));
+    size_t j = (i + rand_offset) % wallets.size();
+    assertNotEqual(i, j);
+
+    auto& w1 = wallets[i];
+    auto& w2 = wallets[j];
+    Simulation::assertSerialization(w1);
+    Simulation::assertSerialization(w2);
+
+    const size_t balance = Simulation::calcBalance(w1);
+    const size_t budget = Simulation::calcBudget(w1);
+    const size_t maxPayment = std::min<size_t>(balance, budget);
+
+    if (maxPayment == 0) {
+      loginfo << "No payment possible. [balance=" << balance << "] [budget=" << budget << "] Skipping.";
+      continue;
+    }
+
+    const size_t payment = static_cast<size_t>(rand()) % maxPayment + 1;  // [1 .. maxPayment]
+
+    loginfo << "Target payment $" << payment << " from '" << w1.ask.pid << "' to '" << w2.ask.pid << "'\n";
+
+    // Precondition: 0 < payment <= budget <= balance
+
+    Client::CreateTxEvent createTxEvent;
+    auto clientTx = Client::createTxForPayment(w1, w2.getUserPid(), payment, createTxEvent);
+
+    for (const size_t value : createTxEvent.inputNormalCoinValues_)
+      loginfo << "'" << w1.ask.pid << "' removing $" << value << " coin" << endl;
+
+    for (const auto& [pid, value] : createTxEvent.recipients_) {
+      if (pid != w1.ask.pid) loginfo << "'" << w1.ask.pid << "' sends $" << value << " to '" << pid << "'" << endl;
+    }
+
+    // Replicas receive, validate and sign the proposed transaction
+    std::vector<std::vector<RandSigShare>> replicaSignShares;
+    {
+      // Simulate client sending a valid transaction to replicas
+      auto replicaTx = Simulation::sendValidTxOnNetwork(ctx, clientTx);
+
+      // Mark input coins as spent
+      Simulation::addNullifiers(replicaTx, nullset);
+
+      // Each replica signs the output coins with its SK share
+      for (auto& bskShare : ctx.bskShares_) {
+        replicaSignShares.emplace_back(Replica::signShareOutputCoins(replicaTx, bskShare));
+      }
+    }
+
+    // Prune spent coins
+    for (auto& w : wallets) {
+      auto result = Client::pruneSpentCoins(w, nullset);
+    }
+
+    // Claim output coins
+    for (size_t txoIdx = 0; txoIdx < clientTx.outs.size(); txoIdx++) {
+      // Sample a subset of sigshares to aggregate
+      std::vector<RandSigShare> sigShareSubset;
+      std::vector<size_t> signerIdSubset = random_subset(ctx.thresh_, ctx.n_);
+      for (auto id : signerIdSubset) {
+        sigShareSubset.push_back(replicaSignShares.at(id).at(txoIdx));
+      }
+
+      // Ensure only one of the wallets identifies this output as theirs and claims it
+      logtrace << "Trying to claim output #" << txoIdx << " on each wallet" << endl;
+      bool claimed = false;
+      for (size_t j = 0; j < wallets.size(); j++) {
+        std::optional<Client::ClaimEvent> claimEvent;
+        Client::tryClaimCoin(wallets.at(j), clientTx, txoIdx, sigShareSubset, signerIdSubset, ctx.n_, claimEvent);
+
+        if (claimEvent) {
+          assertFalse(claimed);
+          loginfo << "Adding a $" << claimEvent->value_ << " '" << (claimEvent->isBudgetCoin_ ? "budget" : "normal")
+                  << "' coin to wallet #" << j + 1 << " for '" << wallets[j].ask.pid << "'" << endl;
+
+          claimed = true;
+        }
+      }
+      assertTrue(claimed);
+    }
+
+  }  // end for all cycles
+
+  // Check total value in the system
+  size_t wallet_value = 0;
+  for (const auto& v : normal_coin_values) wallet_value += v;
+  size_t total_value_expected = wallets.size() * wallet_value;
+
+  size_t total_value_actual = 0;
+  for (const auto& wallet : wallets) {
+    for (const auto& c : wallet.coins) {
+      total_value_actual += c.getValue();
+    }
+  }
+  testAssertEqual(total_value_expected, total_value_actual);
+
+  loginfo << "All is well." << endl;
+
+  return 0;
+}

--- a/utt/libxutils/libxutils/include/xutils/Log.h
+++ b/utt/libxutils/libxutils/include/xutils/Log.h
@@ -55,21 +55,21 @@ int64_t getpid();
 #define logperf std::clog << LOG_PREFIX << "PERF" << LOG_SUFFIX
 #define logerrno logErrNo()
 
-#ifndef NDEBUG
+#ifdef UTT_LOG_DEBUG
 #define logdbg std::clog << LOG_PREFIX << "DEBUG" << LOG_SUFFIX
 #else
 #define logdbg \
   if (false) coredumpOstream()
 #endif
 
-#ifdef TRACE
+#ifdef UTT_LOG_TRACE
 #define logtrace std::clog << LOG_PREFIX << "TRACE" << LOG_SUFFIX
 #else
 #define logtrace \
   if (false) coredumpOstream()
 #endif
 
-#ifdef LOG_ALLOC
+#ifdef UTT_LOG_ALLOC
 #define logalloc std::clog << LOG_PREFIX << "ALLOC" << LOG_SUFFIX
 #else
 #define logalloc \


### PR DESCRIPTION
* **Problem Overview**  
  Improve the usability of the utt client by moving debug log messages to the concord log and making informational messages more clear and understandable to the user. Remove debug messages originating from utt and convert them to info messages emitted by the actual simulation tests.
   * Added a new command 'accounts' to list all account names in the system - this helps to remind us of the possible recipients of money transfers.
   * Wallet coins are now listed in addition to the public and utt balances - this helps to better track how money is moved around.
* **Testing Done**  
   * Manually tested utt transfers and how the new information messages help to track what's going in the demo.
   * Added a new utt test  **TestTxnSimulateUTTDemo_v2** that uses the specific Client/Replica utt methods which were copied over from the simulation code. Checked that the new simulation has the same execution as the old one.
