### PR TITLE
Install UTT dependencies using cmake Externalproject_add

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ option(USE_OPENSSL "Enable use of OpenSSL" ON)
 option(BUILD_THIRDPARTY "Wheter to build third party librarie or use preinstalled ones" OFF)
 option(CODECOVERAGE "Enable Code Coverage Metrics in Clang" OFF)
 option(ENABLE_RESTART_RECOVERY_TESTS "Enable tests for restart recovery" OFF)
+option(BUILD_UTT "Build UTT library" OFF)
 
 if(USE_OPENSSL AND NOT BUILD_THIRDPARTY)
     set(OPENSSL_ROOT_DIR /usr/local/ssl) # not to confuse with system ssl libs
@@ -222,7 +223,7 @@ if(USE_GRPC)
 endif()
 add_subdirectory(ccron)
 # [TODO-UTT] Compile libutt on GCC
-if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if (BUILD_UTT AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     add_subdirectory(utt)
 endif()
 

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -459,104 +459,6 @@ install_ccache(){
   mkdir -p /mnt/ccache/
 }
 
-install_libsodium(){
-    # Cryptographic library (used in libutt)
-    cd ${HOME}
-    wget ${WGET_FLAGS} https://download.libsodium.org/libsodium/releases/libsodium-1.0.18.tar.gz -O libsodium.tar.gz
-    tar -xvzf libsodium.tar.gz
-    cd libsodium-1.0.18
-    ./configure
-    make -j${NUM_CPUS} && make check
-    sudo make install
-    cd ${HOME}
-    rm -rf libsodium.tar.gz libsodium-1.0.18
-}
-
-install_ntl(){
-    # Number theory library (used in libutt)
-    cd ${HOME}
-    wget ${WGET_FLAGS} https://libntl.org/ntl-11.5.1.tar.gz -O ntl.tar.gz
-    tar -xvzf ntl.tar.gz
-    cd ntl-11.5.1/src 
-    ./configure
-    make -j${NUM_CPUS}
-    sudo make install
-    cd ${HOME}
-    rm -rf ntl.tar.gz ntl-11.5.1
-}
-
-install_ate_pairing(){
-    # Compute optimal ate pairings over BN curves (used in libutt)
-    cd ${HOME}
-    git clone https://github.com/herumi/ate-pairing.git ate-pairing
-    cd ate-pairing/
-    git checkout 530223d7502e95f6141be19addf1e24d27a14d50
-
-    ATE_PAIRING_FLAGS="DBG=on"
-
-    make -j $NUM_CPUS -C src \
-        SUPPORT_SNARK=1 \
-        $ATE_PAIRING_FLAGS
-
-    INCL_DIR=/usr/local/include/ate-pairing/include
-    sudo mkdir -p "$INCL_DIR"
-    sudo cp include/bn.h  "$INCL_DIR"
-    sudo cp include/zm.h  "$INCL_DIR"
-    sudo cp include/zm2.h "$INCL_DIR"
-
-    LIB_DIR=/usr/local/lib
-    sudo cp lib/libzm.a "$LIB_DIR"
-
-    cd ${HOME}
-    rm -rf ate-pairing/
-}
-
-install_libff(){
-    # Finite fields and elliptic curves library (used in libutt)
-    cd ${HOME}
-    git clone https://github.com/scipr-lab/libff.git libff
-    cd libff/
-    git checkout a152abfcef21b7778cece96fe77f5e0f819ba79e
-
-    mkdir -p build/
-    cd build/
-    # WARNING: Does not link correctly with -DPERFORMANCE=ON
-    cmake \
-        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-        -DCMAKE_INSTALL_PREFIX=/usr/local \
-        -DIS_LIBFF_PARENT=OFF \
-        -DBINARY_OUTPUT=OFF \
-        -DNO_PT_COMPRESSION=ON \
-        -DCMAKE_CXX_FLAGS="-Wno-unused-parameter -Wno-unused-value -Wno-unused-variable -I$sourcedir $CMAKE_CXX_FLAGS" \
-        -DUSE_ASM=ON \
-        -DPERFORMANCE=OFF \
-        -DMULTICORE=OFF \
-        -DCURVE="BN128" \
-        -DWITH_PROCPS=OFF ..
-
-    make -j $NUM_CPUS
-    sudo make install
-
-    cd ${HOME}
-    rm -rf libff/
-}
-
-install_libfqfft(){
-    # Fast Fourier transforms in finite fields (used in libutt)
-    cd ${HOME}
-    git clone https://github.com/alinush/libfqfft.git libfqfft
-    cd libfqfft/
-    git checkout 1ebd069d2a00254558998c93767efbbbd51f250a
-
-    INCL_DIR=/usr/local/include/libfqfft
-    sudo mkdir -p "$INCL_DIR"
-    sudo cp -r libfqfft/* "$INCL_DIR/"
-    sudo rm "$INCL_DIR/CMakeLists.txt"
-
-    cd ${HOME}
-    rm -rf libfqfft/
-}
-
 install_build_tools
 install_third_party_libraries
 install_cmake
@@ -580,13 +482,6 @@ install_thrift_lib
 install_jaegertracing_cpp_lib
 install_cppcheck
 install_ccache
-
-# libutt dependencies
-install_libsodium
-install_ntl
-install_ate_pairing
-install_libff
-install_libfqfft
 
 # After installing all libraries, let's make sure that they will be found at compile time
 ldconfig -v

--- a/utt/CMakeLists.txt
+++ b/utt/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.2)
 # project(<name> VERSION <ver> LANGUAGES CXX)
 project(libutt VERSION 0.1.0.0 LANGUAGES CXX)
-
+message(STATUS "Building UTT")
 #
 # Configuration options
 #
@@ -80,7 +80,7 @@ link_directories("/usr/local/lib")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../cmake")
 #
 # Compiler flags
 #
@@ -93,7 +93,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # just use signed types everywhere and cast your unsigned to signed when mixing unsigned
 # variables with signed ones. See: http://soundsoftware.ac.uk/c-pitfall-unsigned
 set(CXX_FLAGS_INTEGER_CORRECTNESS 
-    "-Wconversion -Wsign-conversion -Wsign-compare")
+    "-Wno-conversion -Wno-sign-conversion -Wsign-compare -Wno-float-conversion -Wno-unused-parameter -Wno-unknown-pragmas" )
 set(CXX_FLAGS_FORMAT 
     "-Wformat-y2k -Wno-format-extra-args -Wno-format-zero-length -Wformat-nonliteral -Wformat-security -Wformat=2")
 set(CXX_FLAGS_OPTIMIZATIONS "-O3")
@@ -172,6 +172,7 @@ endif()
 #
 enable_testing()
 
+include(dependencies.cmake)
 # Subdirectories
 add_subdirectory(libutt)
 add_subdirectory(libxassert)

--- a/utt/dependencies.cmake
+++ b/utt/dependencies.cmake
@@ -1,0 +1,97 @@
+message(STATUS "Build third parites")
+include(CheckIncludeFile)
+include(CheckIncludeFileCXX)
+include(CheckIncludeFiles)
+include(ExternalProject)
+include(ProcessorCount)
+
+ProcessorCount(NPROC)
+
+set(THIRDPARTY_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR})
+file(MAKE_DIRECTORY ${THIRDPARTY_INSTALL_DIR}/include)
+
+
+ExternalProject_Add(libsodium
+                    PREFIX libsodium
+                    URL "https://download.libsodium.org/libsodium/releases/libsodium-1.0.18.tar.gz"
+                    CONFIGURE_COMMAND ./configure --prefix=${THIRDPARTY_INSTALL_DIR}
+                    BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} -j${NPROC}
+                    BUILD_IN_SOURCE 1
+                    LOG_DOWNLOAD 1
+                    LOG_BUILD 1
+)
+
+ExternalProject_Add(ntl
+                    PREFIX ntl
+                    URL "https://libntl.org/ntl-11.5.1.tar.gz"
+                    CONFIGURE_COMMAND cd src && ./configure PREFIX=${THIRDPARTY_INSTALL_DIR}
+                    BUILD_IN_SOURCE 1
+                    LOG_DOWNLOAD 1
+                    LOG_BUILD 1
+                    BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} -C src -j${NPROC}
+                    INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} -C src install
+)
+set(NTL_INCLUDE_DIR ${THIRDPARTY_INSTALL_DIR}/include)
+set(NTL_LIBRARY ${THIRDPARTY_INSTALL_DIR}/lib/libntl.a)
+message(STATUS "NTL_INCLUDE_DIR ${NTL_INCLUDE_DIR}")
+message(STATUS "NTL_LIBRARY ${NTL_LIBRARY}")
+
+
+ExternalProject_Add(ate_pairing
+                    PREFIX ate_pairing
+                    GIT_REPOSITORY "https://github.com/herumi/ate-pairing.git"
+                    GIT_TAG "530223d7502e95f6141be19addf1e24d27a14d50"
+                    CONFIGURE_COMMAND ""
+                    BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} -C src -j${NPROC} DBG=on SUPPORT_SNAKR=1 
+                    BUILD_IN_SOURCE 1
+                    LOG_DOWNLOAD 1
+                    LOG_BUILD 1
+                    INSTALL_COMMAND install -p -D -t ${THIRDPARTY_INSTALL_DIR}/include/ate-pairing/include 
+                                                  include/bn.h include/zm.h include/zm2.h &&
+                                    install -p -D -t ${THIRDPARTY_INSTALL_DIR}/lib lib/libzm.a
+)
+
+set(ZM_INCLUDE_DIR ${THIRDPARTY_INSTALL_DIR}/include)
+set(ZM_LIBRARY ${THIRDPARTY_INSTALL_DIR}/lib/libzm.a)
+message(STATUS "ZM_INCLUDE_DIR ${ZM_INCLUDE_DIR}")
+message(STATUS "ZM_LIBRARY ${ZM_LIBRARY}")
+
+ExternalProject_Add(libff
+                    PREFIX libff
+                    GIT_REPOSITORY "https://github.com/scipr-lab/libff.git"
+                    GIT_TAG "a152abfcef21b7778cece96fe77f5e0f819ba79e"
+                    GIT_PROGRESS TRUE
+                    LOG_DOWNLOAD 1
+                    LOG_BUILD 1
+                    # WARNING: Does not link correctly with -DPERFORMANCE=ON
+                    CMAKE_ARGS  -DCMAKE_BUILD_TYPE=RelWithDebInfo
+                                -DCMAKE_INSTALL_PREFIX:FILEPATH=${THIRDPARTY_INSTALL_DIR}
+                                -DIS_LIBFF_PARENT=OFF
+                                -DBINARY_OUTPUT=OFF
+                                -DNO_PT_COMPRESSION=ON
+                                -DCMAKE_CXX_FLAGS="-Wno-unused-parameter -Wno-unused-value -Wno-unused-variable"
+                                -DUSE_ASM=ON
+                                -DPERFORMANCE=OFF
+                                -DMULTICORE=OFF
+                                -DCURVE=BN128
+                                -DWITH_PROCPS=OFF
+                    BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} -j${NPROC}
+                    DEPENDS libsodium
+                    DEPENDS ate_pairing
+)
+
+set(LIBFF_INCLUDE_DIR ${THIRDPARTY_INSTALL_DIR}/include)
+set(LIBFF_LIBRARY ${THIRDPARTY_INSTALL_DIR}/lib/libff.a)
+message(STATUS "LIBFF_INCLUDE_DIR ${LIBFF_INCLUDE_DIR}")
+message(STATUS "LIBFF_LIBRARY ${LIBFF_LIBRARY}")
+
+# Fast Fourier transforms in finite fields (used in libutt)
+ExternalProject_Add(libfqfft
+                    PREFIX libfqfft
+                    GIT_REPOSITORY "https://github.com/alinush/libfqfft.git"
+                    GIT_TAG "1ebd069d2a00254558998c93767efbbbd51f250a"
+                    CONFIGURE_COMMAND ""
+                    BUILD_COMMAND "" 
+                    LOG_DOWNLOAD 1
+                    INSTALL_COMMAND cp -rp <SOURCE_DIR>/libfqfft ${THIRDPARTY_INSTALL_DIR}/include
+)

--- a/utt/libutt/src/CMakeLists.txt
+++ b/utt/libutt/src/CMakeLists.txt
@@ -33,18 +33,23 @@ add_library(utt
 )
 
 find_package(OpenSSL REQUIRED)
+add_dependencies(utt libfqfft ntl libff)
+
 target_include_directories(utt PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>"
     "$<INSTALL_INTERFACE:${INSTALL_CMAKE_DIR}/include>"
+    ${LIBFF_INCLUDE_DIR}
+    ${NTL_INCLUDE_DIR}
+    ${ZM_INCLUDE_DIR}
 )
 
 if(APPLE)
     target_link_libraries(utt PUBLIC
-        ntl ff pthread zm gmp gmpxx xutils xassert OpenSSL::Crypto
+        ${NTL_LIBRARY} ${LIBFF_LIBRARY} pthread ${ZM_LIBRARY} gmp gmpxx xutils xassert OpenSSL::Crypto
     )
 else()
     target_link_libraries(utt PUBLIC
-        ntl ff pthread zm gmp gmpxx xutils xassert stdc++fs OpenSSL::Crypto
+        ${NTL_LIBRARY} ${LIBFF_LIBRARY} pthread ${ZM_LIBRARY} gmp gmpxx xutils xassert stdc++fs OpenSSL::Crypto
     )
 endif()
 

--- a/utt/libxutils/CMakeLists.txt
+++ b/utt/libxutils/CMakeLists.txt
@@ -18,13 +18,7 @@ project(libxutils VERSION 0.1.0.0 LANGUAGES CXX)
 #
 # Dependencies
 #
-find_package(xassert QUIET)
 
-if(xassert_FOUND)
-    message("xassert library is installed!")
-else()
-    message("xassert library not installed. Please download, build and install from https://github.com/alinush/xassert")
-endif()
 
 #find_package(Threads REQUIRED)
 #find_package(Boost 1.65 COMPONENTS program_options REQUIRED)


### PR DESCRIPTION
Install UTT dependencies using cmake `Externalproject_add` instead of `install_deps.sh`.
Dependencies are installed into the `build/include` and `build/lib` directories in the building tree.
Enable UTT build independent of concord-bft by invoking cmake in a `utt/build` directory as it planned to move to a separate repository.
Introduce `BUILD_UTT(=OFF)` option in concord-bft for enabling UTT build as a part of concord-bft.
